### PR TITLE
Typo fix in import filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ## :clipboard: Example
 ```ts
 // Dependencies
-import {Deffy} from "https://deno.land/x/deffy/lib/typpy.ts"
+import {Deffy} from "https://deno.land/x/deffy/lib/deffy.ts"
 
 console.log(Deffy(undefined, "Hello World"));
 // => "Hello World"


### PR DESCRIPTION
This is at least what works for me, and I don't see a `typpy.ts` in the repo, so I'm guessing this is correct.